### PR TITLE
Prefix a type

### DIFF
--- a/src/pf2e/identify.ts
+++ b/src/pf2e/identify.ts
@@ -1,4 +1,4 @@
-import { DCOptions, adjustDCByRarity, calculateDC } from "./dc";
+import { type DCOptions, adjustDCByRarity, calculateDC } from "./dc";
 import { setHasElement } from "./misc";
 import { MAGIC_TRADITIONS } from "./spell";
 import * as R from "remeda";


### PR DESCRIPTION
Fixes `'DCOptions' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.`